### PR TITLE
Fix Try/Catch Block

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "fast-xml2js",
-  "version": "1.0.7",
+  "name": "@travelbank/fast-xml2js",
+  "version": "1.0.8",
   "description": "In-place replacement for xml2js parseString. This is about 20x-30x faster and makes use of the rapidxml C++ library.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Thanks for the work on this. With invalid XML, we were getting an exception from C++ which was terminating the thread. Moved the try, of the try/catch block, up so that the thread doesn't die.

Link without whitespace fixes: https://github.com/cmrigney/fast-xml2js/pull/9/files?w=1