### PR TITLE
Fix to build on node 10.x 

### DIFF
--- a/fast-xml2js.cpp
+++ b/fast-xml2js.cpp
@@ -44,11 +44,13 @@ void ParseString(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
-  Local<Context> ctx = Context::New(isolate);
+  Local<Context> ctx = isolate->GetCurrentContext();
 
-  v8::String::Utf8Value param1(args[0]);
-  char *xml = new char[param1.length() + 1];
-  std::strcpy(xml, *param1);
+  // String::Utf8Value param1(args[0]);
+  auto param1 = args[0]->ToString(ctx).ToLocalChecked();
+  char *xml = new char[param1->Length() + 1];
+  // std::strcpy(xml, param1->)
+  param1->WriteUtf8(isolate, xml);
 
   Local<Object> obj = Object::New(isolate);
   Local<Value> errorString = Null(isolate);

--- a/fast-xml2js.cpp
+++ b/fast-xml2js.cpp
@@ -44,12 +44,10 @@ void ParseString(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
-  Local<Context> ctx = isolate->GetCurrentContext();
+  Local<Context> context = Context::New(isolate);
 
-  // String::Utf8Value param1(args[0]);
-  auto param1 = args[0]->ToString(ctx).ToLocalChecked();
+  auto param1 = args[0]->ToString(context).ToLocalChecked();
   char *xml = new char[param1->Length() + 1];
-  // std::strcpy(xml, param1->)
   param1->WriteUtf8(isolate, xml);
 
   Local<Object> obj = Object::New(isolate);
@@ -92,7 +90,7 @@ void ParseString(const FunctionCallbackInfo<Value>& args) {
         if(node != doc.first_node())
         {
 
-          bool hasProperty = obj->HasOwnProperty(ctx, String::NewFromUtf8(isolate, node->name())).FromMaybe(false);
+          bool hasProperty = obj->HasOwnProperty(context, String::NewFromUtf8(isolate, node->name())).FromMaybe(false);
           if(hasProperty)
           {
             lst = Local<Array>::Cast(obj->Get(String::NewFromUtf8(isolate, node->name())));
@@ -116,7 +114,7 @@ void ParseString(const FunctionCallbackInfo<Value>& args) {
         Local<Array> lst;
         if(node != doc.first_node())
         {
-          bool hasProperty = obj->HasOwnProperty(ctx, String::NewFromUtf8(isolate, node->name())).FromMaybe(false);
+          bool hasProperty = obj->HasOwnProperty(context, String::NewFromUtf8(isolate, node->name())).FromMaybe(false);
           if(hasProperty)
           {
             lst = Local<Array>::Cast(obj->Get(String::NewFromUtf8(isolate, node->name())));

--- a/fast-xml2js.cpp
+++ b/fast-xml2js.cpp
@@ -44,8 +44,9 @@ void ParseString(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
-  String::Utf8Value param1(args[0]->ToString());
+  Local<Context> ctx = Context::New(isolate);
 
+  v8::String::Utf8Value param1(args[0]);
   char *xml = new char[param1.length() + 1];
   std::strcpy(xml, *param1);
 
@@ -59,7 +60,7 @@ void ParseString(const FunctionCallbackInfo<Value>& args) {
     doc.parse<0>(xml);
 
     std::stack<xml_node<> *> nodeStack;
-    std::stack<Local<Object> > objStack;
+    std::stack<Local<Object>> objStack;
 
     nodeStack.push(doc.first_node());
     objStack.push(obj);
@@ -79,8 +80,6 @@ void ParseString(const FunctionCallbackInfo<Value>& args) {
       Local<Object> newObj = Object::New(isolate);
 
       bool hasChild = false;
-
-      Local<Context> ctx = Context::New(isolate);
 
       //Need to reduce duplicate code here
       if(!node->first_node() || (node->first_node() && node->first_node()->type() != node_cdata && node->first_node()->type() != node_data))

--- a/fast-xml2js.cpp
+++ b/fast-xml2js.cpp
@@ -12,6 +12,7 @@ using v8::FunctionCallbackInfo;
 using v8::Isolate;
 using v8::Local;
 using v8::Object;
+using v8::Context;
 using v8::String;
 using v8::Number;
 using v8::Value;
@@ -79,6 +80,8 @@ void ParseString(const FunctionCallbackInfo<Value>& args) {
 
       bool hasChild = false;
 
+      Local<Context> ctx = Context::New(isolate);
+
       //Need to reduce duplicate code here
       if(!node->first_node() || (node->first_node() && node->first_node()->type() != node_cdata && node->first_node()->type() != node_data))
       {
@@ -87,7 +90,9 @@ void ParseString(const FunctionCallbackInfo<Value>& args) {
         Local<Array> lst;
         if(node != doc.first_node())
         {
-          if(obj->HasOwnProperty(String::NewFromUtf8(isolate, node->name())))
+
+          bool hasProperty = obj->HasOwnProperty(ctx, String::NewFromUtf8(isolate, node->name())).FromMaybe(false);
+          if(hasProperty)
           {
             lst = Local<Array>::Cast(obj->Get(String::NewFromUtf8(isolate, node->name())));
             lst->Set(String::NewFromUtf8(isolate, "length"), Number::New(isolate, lst->Length() + 1));
@@ -110,7 +115,8 @@ void ParseString(const FunctionCallbackInfo<Value>& args) {
         Local<Array> lst;
         if(node != doc.first_node())
         {
-          if(obj->HasOwnProperty(String::NewFromUtf8(isolate, node->name())))
+          bool hasProperty = obj->HasOwnProperty(ctx, String::NewFromUtf8(isolate, node->name())).FromMaybe(false);
+          if(hasProperty)
           {
             lst = Local<Array>::Cast(obj->Get(String::NewFromUtf8(isolate, node->name())));
             lst->Set(String::NewFromUtf8(isolate, "length"), Number::New(isolate, lst->Length() + 1));


### PR DESCRIPTION
Right now fast-xml2js works on node 8.x, this will allow for installing it as dependency for projects that are using current LTS (10.x) version of node